### PR TITLE
Added new AMI to enable deployment in Stockholm

### DIFF
--- a/templates/nodecreate.template
+++ b/templates/nodecreate.template
@@ -154,6 +154,8 @@ Mappings:
       AMZNLINUXHVM: ami-050b8344d77081f4b
     eu-west-3:
       AMZNLINUXHVM: ami-053418e626d0549fc
+    eu-north-1:
+      AMZNLINUXHVM: ami-8c169ef2
     sa-east-1:
       AMZNLINUXHVM: ami-05b7dbc290217250d
     us-east-1:


### PR DESCRIPTION
Added new ami which is AMZNLINUXHVM for [eu-north-1 (Stockholm)](https://github.com/99stealth/cfn-ami-to-mapping/blob/master/README.md) to enable deployment in Stockholm.